### PR TITLE
Small fixes to snakefile

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ probe_design:
     lcf_thres: 100
     coverage: 1.0
     probe_stride_full: 60
-    probe_stride_ends: 30
+    probe_stride_ends: 60
     segment_end_size: 500  # Size of the segment ends (flanks) in bp
   orthohanta:
     mismatches: 5

--- a/envs/seqkit.yaml
+++ b/envs/seqkit.yaml
@@ -3,3 +3,5 @@ channels:
   - bioconda
 dependencies:
   - seqkit
+  - gawk
+  - bc


### PR DESCRIPTION
This pull request includes several updates to the `baitdesign.smk` file, focusing on improving the handling of blacklist files, enhancing the probe deduplication process, and expanding the probe coverage analysis. Additionally, there are minor configuration changes in `config.yaml` and `envs/seqkit.yaml`.

### Improvements to blacklist handling:
* [`baitdesign.smk`](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL31-L46): Removed the `concatenate_blacklist` rule and updated rules to accept multiple blacklist files directly. [[1]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL31-L46) [[2]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL81-R65) [[3]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL113-R97) [[4]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL145-R129)

### Enhancements to probe deduplication:
* [`baitdesign.smk`](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aR189-R223): Enhanced the `deduplicate_probes` rule to include detailed logging of probe counts and lengths before and after deduplication.

### Expansions to probe coverage analysis:
* [`baitdesign.smk`](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aR261-R305): Expanded the `analyze_probe_coverage` rule to include coverage analysis for Puumala flanks and improved logging with a comprehensive coverage report.

### Configuration updates:
* [`config.yaml`](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L29-R29): Updated `probe_stride_ends` from 30 to 60.
* [`envs/seqkit.yaml`](diffhunk://#diff-4637d984d1d636a3dafd44681bfe1c15e7566de1e0d0b43f4e584da7bad08aa7R6-R7): Added `gawk` and `bc` dependencies.