### PR TITLE
Small fixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,9 +25,10 @@ probe_design:
     mismatches: 2
     lcf_thres: 100
     coverage: 1.0
-    probe_stride_full: 60
-    probe_stride_ends: 30
-    segment_end_size: 500  # Size of the segment ends (flanks) in bp
+    probe_stride: 60
+    segment_end_stride: 30
+    # Size of the segment ends (flanks) in bp
+    segment_end_size: 500
   orthohanta:
     mismatches: 5
     lcf_thres: 90


### PR DESCRIPTION
This pull request includes significant updates to the `baitdesign.smk` pipeline, focusing on improving the probe design process for Puumala and other orthohantaviruses. Key changes include renaming and modifying rules for better clarity and functionality, updating parameters, and reorganizing the pipeline into distinct steps.

### Key Changes:

**Pipeline Reorganization:**
* Reorganized the pipeline into three distinct steps: Design, Combine-Filter, and Validate. This improves readability and structure. [[1]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL31-R47) [[2]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL151-R234)

**Rule Modifications:**
* Renamed and updated the rule `extract_puumala_segment_ends` to `extract_puumala_segments` to include extraction of segment middles.
* Renamed and updated the rule `design_probes_puumala_full` to `design_probes_puumala_middles` to focus on segment middles with 1x coverage.
* Replaced the deduplication step with a new filtering step using `design.py` to perform set cover filtering and avoid host genomes.

**Parameter Updates:**
* Updated `config.yaml` to consolidate probe stride parameters and clarify segment end size.

**New and Updated Rules:**
* Added a new rule `combine_candidate_probes` to combine all candidate probes into a single FASTA file.
* Updated the `final_probe_set` rule to use the filtered probes instead of deduplicated probes.

These changes enhance the functionality, clarity, and organization of the pipeline, making it more efficient and easier to maintain.