### PR TITLE
Filter problematic oligos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,8 @@ analysis:
   lcf_thres_puumala: 100
   mismatches_orthohanta: 5
   lcf_thres_orthohanta: 90
-
+  max_host_hits: 2  # Maximum allowed hits in host genomes
+  
 # Output directories
 output_dirs:
   probes: "results/probes"


### PR DESCRIPTION
This pull request introduces several enhancements to the `baitdesign.smk` file, focusing on improving the design and analysis of probes, particularly in relation to host genome mappings. The most significant changes include adding new rules for host genome mapping analysis, updating the `rule all` to include new analysis steps, and modifying existing rules to integrate the new functionalities.

Enhancements to probe design and analysis:

* Added `ruleorder` and `wildcard_constraints` to define the order of rules and constraints for design stem wildcards. (`baitdesign.smk`)
* Updated `rule all` to include steps for analyzing host genome mapping counts and final probe analysis in host genomes. (`baitdesign.smk`) [[1]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aR192-R193) [[2]](diffhunk://#diff-7fa9a1d03f584877d42c3ebdec4c58ea8aa47cf30953ebe3bf7352d44cc7de9aL205-R216)

New rules for host genome mapping analysis:

* Introduced `rule count_host_mappings` to count the number of times each oligo is mapped across all host genomes. (`baitdesign.smk`)
* Added `rule filter_high_host_hits` to filter probes with high host genome hits. (`baitdesign.smk`)
* Created `rule analyze_host_matches_in_final` to identify oligos from host probe counts that appear in final probe sets. (`baitdesign.smk`)

Configuration updates:

* Updated `config.yaml` to include the `max_host_hits` parameter, which defines the maximum allowed hits in host genomes. (`config.yaml`)